### PR TITLE
supress NDEBUG redefinition warning.

### DIFF
--- a/include/BCMTools.h
+++ b/include/BCMTools.h
@@ -30,7 +30,9 @@ namespace BCMT_NAMESPACE {
 
 /// DEBUGマクロの定義時のみassertマクロを有効に.
 #ifndef DEBUG
+#ifndef NDEBUG
 #define NDEBUG
+#endif
 #endif
 #include <cassert>
 


### PR DESCRIPTION
This simple patch suppresses NDEBUG redefinition warning.

```
BCMTools/include/BCMTools.h:33:1: warning: "NDEBUG" redefined
```