### PR TITLE
Reorder "mpi.h" header inclusion to fix compilation error 

### DIFF
--- a/include/BCMTools.h
+++ b/include/BCMTools.h
@@ -17,6 +17,8 @@
 #ifndef BCM_TOOLS_H
 #define BCM_TOOLS_H
 
+#include "mpi.h"
+
 #include<cstdio>
 #include<cstdlib>
 

--- a/include/NeighborInfo.h
+++ b/include/NeighborInfo.h
@@ -20,6 +20,8 @@
 #include "BCMTools.h"
 #include "mpi.h"
 
+#include <iostream>
+
 #ifdef BCMT_NAMESPACE
 namespace BCMT_NAMESPACE {
 #endif

--- a/include/Scalar3D.h
+++ b/include/Scalar3D.h
@@ -17,8 +17,8 @@
 #ifndef SCALAR_3D_H
 #define SCALAR_3D_H
 
-#include "DataClass.h"
 #include "VCUpdater.h"
+#include "DataClass.h"
 #include "Index3D.h"
 
 #ifdef BCMT_NAMESPACE

--- a/include/Vector3D.h
+++ b/include/Vector3D.h
@@ -17,8 +17,8 @@
 #ifndef VECTOR_3D_H
 #define VECTOR_3D_H
 
-#include "DataClass.h"
 #include "VCUpdater.h"
+#include "DataClass.h"
 #include "Index3D.h"
 
 #ifdef BCMT_NAMESPACE


### PR DESCRIPTION
When using Intel MPI compiler(mpiicc, mpiicpc), we get the following error:

    /usr/local/intel/impi/4.1.0.024/intel64/include/mpicxx.h(95):
    catastrophic error: #error directive: "SEEK_SET is #defined but must not
    be for the C++ binding of MPI. Include mpi.h before stdio.h"
    #error "SEEK_SET is #defined but must not be for the C++ binding of MPI.
    Include mpi.h before stdio.h"

This patch fixes this error.